### PR TITLE
initial implementation

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -339,6 +339,10 @@ program
     '-H, --hostname <hostname>',
     'Specify a hostname on which to start the application (default: 0.0.0.0).'
   )
+  .option(
+    '--access-log <path>',
+    'Specify the path to where to write the access log.'
+  )
   .addOption(
     new Option(
       '--keepAliveTimeout <keepAliveTimeout>',

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -26,7 +26,7 @@ const nextStart = async (options: NextStartOptions, directory?: string) => {
   const dir = getProjectDir(directory)
   const hostname = options.hostname
   const port = options.port
-  const accessLog = options.accessLog;
+  const accessLog = options.accessLog
   const keepAliveTimeout = options.keepAliveTimeout
 
   if (isPortIsReserved(port)) {
@@ -39,7 +39,7 @@ const nextStart = async (options: NextStartOptions, directory?: string) => {
     hostname,
     port,
     keepAliveTimeout,
-    accessLog
+    accessLog,
   })
 }
 

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -13,6 +13,7 @@ export type NextStartOptions = {
   port: number
   hostname?: string
   keepAliveTimeout?: number
+  accessLog?: string
 }
 
 /**
@@ -25,6 +26,7 @@ const nextStart = async (options: NextStartOptions, directory?: string) => {
   const dir = getProjectDir(directory)
   const hostname = options.hostname
   const port = options.port
+  const accessLog = options.accessLog;
   const keepAliveTimeout = options.keepAliveTimeout
 
   if (isPortIsReserved(port)) {
@@ -37,6 +39,7 @@ const nextStart = async (options: NextStartOptions, directory?: string) => {
     hostname,
     port,
     keepAliveTimeout,
+    accessLog
   })
 }
 

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -147,12 +147,15 @@ export async function startServer(
   }
 
   async function requestListener(req: IncomingMessage, res: ServerResponse) {
-    if(accessLog) {
+    if (accessLog) {
       try {
-          fs.appendFileSync(accessLog, `${new Date().toISOString()} ${req.method} ${req.url} ${req.headers['user-agent']}\n`);
+        fs.appendFileSync(
+          accessLog,
+          `${new Date().toISOString()} ${req.method} ${req.url} ${req.headers['user-agent']}\n`
+        )
       } catch (err) {
-          Log.error(`Failed to write to access log: ${accessLog}`);
-          console.error(err);
+        Log.error(`Failed to write to access log: ${accessLog}`)
+        console.error(err)
       }
     }
     try {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -46,6 +46,7 @@ export interface StartServerOptions {
   allowRetry?: boolean
   customServer?: boolean
   minimalMode?: boolean
+  accessLog?: string
   keepAliveTimeout?: number
   // this is dev-server only
   selfSignedCertificate?: SelfSignedCertificate
@@ -100,6 +101,7 @@ export async function startServer(
     allowRetry,
     keepAliveTimeout,
     selfSignedCertificate,
+    accessLog,
   } = serverOptions
   let { port } = serverOptions
 
@@ -145,6 +147,14 @@ export async function startServer(
   }
 
   async function requestListener(req: IncomingMessage, res: ServerResponse) {
+    if(accessLog) {
+      try {
+          fs.appendFileSync(accessLog, `${new Date().toISOString()} ${req.method} ${req.url} ${req.headers['user-agent']}\n`);
+      } catch (err) {
+          Log.error(`Failed to write to access log: ${accessLog}`);
+          console.error(err);
+      }
+    }
     try {
       if (handlersPromise) {
         await handlersPromise


### PR DESCRIPTION
Closes #22945
Could aid #35444, #45442

## Motivation
Currently, there is no built-in way to log HTTP requests handled by the Next.js web server, whether they are serving static, SSR, or API responses. This feature is often essential for monitoring and debugging production environments. The issue requests a mechanism to enable logging of HTTP requests similar to traditional access logs.

## Implementation
This PR introduces a new feature to the Next.js web server: the ability to start the server with an additional `--access-log <filename>` flag. When this flag is provided, the server writes HTTP request logs to the specified file in the standard access log format, e.g.,:

```
127.0.0.1 2024-12-31T11:36:08.516Z GET /info?_rsc=1ld0r Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
```

### Example Usage
To enable access logging, start the Next.js web server with the following command:
```bash
next start --access-log access.log
```

## Breakings
This PR does not introduce breaking changes. It adds a new optional feature that is backwards-compatible with existing server configurations.

### Benefits
* Seamless integration for production monitoring.
* No additional dependencies or middleware required.
* Simple log format for easy parsing and analysis.